### PR TITLE
ci: add test, sec scorecard,dep-check, licenselint

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 IDsec Solutions AB
+#
+# SPDX-License-Identifier: CC0-1.0
+
+---
+name: OpenSSF Scorecard analysis
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly.
+    - cron: "30 1 * * 6"
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard-analysis:
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    uses: diggsweden/.github/.github/workflows/openssf-scorecard.yml@main

--- a/.github/workflows/pullrequest-workflow.yml
+++ b/.github/workflows/pullrequest-workflow.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 IDsec Solutions AB
+#
+# SPDX-License-Identifier: CC0-1.0
+
+---
+name: Pull Request Workflow
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependencyreviewlint:
+    uses: diggsweden/.github/.github/workflows/dependency-review.yml@main
+  licenselint:
+    uses: diggsweden/.github/.github/workflows/license-lint.yml@main
+  test:
+    permissions:
+      contents: read
+      packages: read
+    if: always()
+    needs: [licenselint,dependencyreviewlint]
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 IDsec Solutions AB 
+#
+# SPDX-License-Identifier: CC0-1.0
+
+---
+name: Maven Test
+
+on: [workflow_call]  # yamllint disable-line rule:truthy
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: ['21'] 
+        os: [ubuntu-latest, macos-latest]
+
+    env: 
+      MAVEN_CLI_OPTS: "--batch-mode --no-transfer-progress --errors --fail-at-end -Dstyle.color=always -DinstallAtEnd=true -DdeployAtEnd=true"
+    
+    permissions:
+      contents: read
+      packages: read
+    
+    steps:
+      - name: Harden GitHub runner
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up JDK
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'  # Popular Java distribution
+          cache: 'maven'  # Enables Maven caching
+
+      - name: Run tests
+        env: 
+          GITHUB_ACTOR: ${{ github.actor }}
+          PACKAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn $MAVEN_CLI_OPTS test

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![Tag](https://img.shields.io/github/v/tag/idsec-solutions/cose?style=for-the-badge&color=green)](https://github.com/idsec-solutions/cose/tags)
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/idsec-solutions/cose/badge?style=for-the-badge)](https://scorecard.dev/viewer/?uri=github.com/idsec-solutions/cose)
+
 This project is a Java implementation of the IETF CBOR Encoded Message Syntax (COSE).  
 COSE is specified in [RFC 8152](https://tools.ietf.org/html/rfc8152).
 


### PR DESCRIPTION
Adds workflows for prcheck:
- Dependency Analysis,
- Licenselint,
- Test if success.

Also adds an OpenSSF- scorecard and evaluation.

NOTE: Some of the flows are currently pointing to general components in another github-org. I have asked admins of idsec-solutions org access to  a organisation repo (.github) and then the flows can be adjusted to point correctly to idsecs organisation repo instead.. They are CC0 (public domain style) so are free to reuse.